### PR TITLE
fix: update title template

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -12,6 +12,11 @@ const config: DocsThemeConfig = {
   faviconGlyph:"📝",
   search:{
     placeholder:"Search"
+  },
+  useNextSeoProps() {
+    return {
+      titleTemplate: '%s – Student Benefits'
+    }
   }
 }
 


### PR DESCRIPTION
This PR updates the title template in `theme.config.tsx` to display "Student Benefits" instead of "Nextra".

Before:
<img width="307" alt="image" src="https://github.com/kapoorsaumitra/studentbenefits/assets/118043566/7060dbb6-21c8-401b-a8cf-70876b7c8ca2">

After:
<img width="419" alt="image" src="https://github.com/kapoorsaumitra/studentbenefits/assets/118043566/7ea4e4e3-6a6d-471f-ade2-2662ad7cacdd">
